### PR TITLE
Parallelizing color sampling for a pixel

### DIFF
--- a/include/std/ranges.hpp
+++ b/include/std/ranges.hpp
@@ -44,4 +44,14 @@ constexpr auto chunk_pair(Range &&rng) {
   });
 }
 } // namespace views
+namespace ranges {
+template <std::ranges::input_range Range> auto to_vector(Range &&rng) {
+  using value_type = std::ranges::range_value_t<Range>;
+  std::vector<value_type> res;
+  for (auto n : rng) {
+    res.push_back(std::move(n));
+  }
+  return res;
+}
+}; // namespace ranges
 } // namespace mrl


### PR DESCRIPTION
For rendering a pixel we throw n rays on viewport and render the average color of those rays. We refer this process as sampling. Because multiple rays are being sent and then being averaged, this process is good candidate for parallelisation. 

However, parallel code is not performing any better than the sequential one. There can be multiple reason for the same. Some of them are:
- For rendering each pixel, we actually do some memory allocation. This itself is taking so much time. Instead some kind of smart local allocators could help in this case to avoid OS calls.
- There can be also a case for too much parallelism. It can be possible that sequentially computing the colors of each pixel is fast enough and parllelizing the same can be overhead.

Good level of profiling needs to be done for better insights. It would also help to gain more aspect of concurrency.